### PR TITLE
Add simple access to cleaning the conda cache/index/...

### DIFF
--- a/src/CondaPkg.jl
+++ b/src/CondaPkg.jl
@@ -668,7 +668,7 @@ end
 Remove unused packages and caches.
 """
 function gc()
-    cmd = MicroMamba.cmd(`clean -y -all`)
+    cmd = MicroMamba.cmd(`clean -y --all`)
     @info "Remove unused packages and caches " cmd.exec 
     run(cmd)
     nothing

--- a/src/CondaPkg.jl
+++ b/src/CondaPkg.jl
@@ -664,19 +664,19 @@ function rm_pip(pkg::AbstractString)
 end
 
 """
-    clean(;
-        clean_all=true, index=false, packages=false, tarballs=false, 
+    gc(;
+        all=true, index=false, packages=false, tarballs=false, 
         tempfiles=false, force=false, debug=true, dry_run=false, quiet=false
     )
 Remove unused packages and caches.
 """
-function clean(;
-    clean_all=true, index=false, packages=false, tarballs=false, 
+function gc(;
+    all=true, index=false, packages=false, tarballs=false, 
     tempfiles=false, force=false, debug=true, dry_run=false, quiet=false
 )
-    kwargs = [clean_all, index, packages, tarballs, tempfiles, force, 
+    kwargs = [all, index, packages, tarballs, tempfiles, force, 
             debug, dry_run, quiet]
-    if !clean_all & !any(kwargs[2:5])
+    if all & !any(kwargs[2:5])
         @warn(
             "Please specify 1 or more of the conda artifacts to clean up (e.g., `index=true`)."
         )

--- a/src/CondaPkg.jl
+++ b/src/CondaPkg.jl
@@ -663,4 +663,39 @@ function rm_pip(pkg::AbstractString)
     return
 end
 
+"""
+    clean(;
+        clean_all=true, index=false, packages=false, tarballs=false, 
+        tempfiles=false, force=false, debug=true, dry_run=false, quiet=false
+    )
+Remove unused packages and caches.
+"""
+function clean(;
+    clean_all=true, index=false, packages=false, tarballs=false, 
+    tempfiles=false, force=false, debug=true, dry_run=false, quiet=false
+)
+    kwargs = [clean_all, index, packages, tarballs, tempfiles, force, 
+            debug, dry_run, quiet]
+    if !clean_all & !any(kwargs[2:5])
+        @warn(
+            "Please specify 1 or more of the conda artifacts to clean up (e.g., `index=true`)."
+        )
+    end
+    flags = [
+        "--all",
+        "--index-cache",
+        "--packages",
+        "--tarballs",
+        "--tempfiles",
+        "--force-pkgs-dirs",
+        "--debug",
+        "--dry-run",
+        "--quiet"
+    ][kwargs]
+    cmd = MicroMamba.cmd(`clean -y $flags`)
+    @info "Remove unused packages and caches " cmd.exec 
+    run(cmd)
+    nothing
+end
+
 end # module

--- a/src/CondaPkg.jl
+++ b/src/CondaPkg.jl
@@ -664,35 +664,11 @@ function rm_pip(pkg::AbstractString)
 end
 
 """
-    gc(;
-        all=true, index=false, packages=false, tarballs=false, 
-        tempfiles=false, force=false, debug=true, dry_run=false, quiet=false
-    )
+    gc()
 Remove unused packages and caches.
 """
-function gc(;
-    all=true, index=false, packages=false, tarballs=false, 
-    tempfiles=false, force=false, debug=true, dry_run=false, quiet=false
-)
-    kwargs = [all, index, packages, tarballs, tempfiles, force, 
-            debug, dry_run, quiet]
-    if all & !any(kwargs[2:5])
-        @warn(
-            "Please specify 1 or more of the conda artifacts to clean up (e.g., `index=true`)."
-        )
-    end
-    flags = [
-        "--all",
-        "--index-cache",
-        "--packages",
-        "--tarballs",
-        "--tempfiles",
-        "--force-pkgs-dirs",
-        "--debug",
-        "--dry-run",
-        "--quiet"
-    ][kwargs]
-    cmd = MicroMamba.cmd(`clean -y $flags`)
+function gc()
+    cmd = MicroMamba.cmd(`clean -y -all`)
     @info "Remove unused packages and caches " cmd.exec 
     run(cmd)
     nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,4 +73,10 @@ using Test
         @test !isfile(curl_path)
     end
 
+    
+    @testset "clean()" begin
+        # verify that clean runs without errors
+        CondaPkg.clean()
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,9 +74,9 @@ using Test
     end
 
     
-    @testset "clean()" begin
-        # verify that clean runs without errors
-        CondaPkg.clean()
+    @testset "gc()" begin
+        # verify that micromamba clean runs without errors
+        CondaPkg.gc()
     end
 
 end


### PR DESCRIPTION
Similar to Conda.jl, I think having access to cleaning the environments, without importing and manually doing the micromamba command, would be beneficial. Let me know what you think