### PR TITLE
Add `file://` prefix to local pip package versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CondaPkg"
 uuid = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 authors = ["Christopher Doris <github.com/cjdoris>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -98,6 +98,10 @@ function _resolve_merge_pip_packages(packages)
                 if startswith(url, ".")
                     url = abspath(dirname(fn), url)
                 end
+                if startswith(url, "/")
+                    # https://peps.python.org/pep-0440/#direct-references
+                    url = "file://"*url
+                end
                 push!(urls, url)
             elseif pkg.version != ""
                 push!(versions, pkg.version)


### PR DESCRIPTION
pip apparently requires a `file://` prefix for local paths to Python packages: https://peps.python.org/pep-0440/#direct-references