### PR TITLE
move the version location in specstr

### DIFF
--- a/src/spec.jl
+++ b/src/spec.jl
@@ -57,13 +57,13 @@ validate_build(build) =
 
 function specstr(x::PkgSpec)
     parts = String[]
-    # always include the version, working around a bug in micromamba that the build is
-    # ignored if the version is not set at all
-    push!(parts, "version='$(x.version == "" ? "*" : x.version)'")
     x.channel == "" || push!(parts, "channel='$(x.channel)'")
     x.build == "" || push!(parts, "build='$(x.build)'")
     suffix = isempty(parts) ? "" : string("[", join(parts, ","), "]")
-    string(x.name, suffix)
+    # always include the version, working around a bug in micromamba that the build is
+    # ignored if the version is not set at all
+    version = x.version == "" ? "=*" : "=$(x.version)"
+    string(x.name, suffix, version)
 end
 
 struct ChannelSpec


### PR DESCRIPTION
This is my attempt to solve unexpected behavior that I have come across when using CondaPkg.jl. Let me know if you think it is needed/if I should make any changes. This is also resolved by including `=` in the version. I may have just been naive with my use of the package, but I did not expect this behavior. 

Short Summary:

When resolving package versions, micromamba does not use the latest patch of a package if the version info is inside the brackets, `[]`.

Example:

I want to add Python 3.9 to an environment, so I run the following commands:

```julia
julia> using CondaPkg
julia> CondaPkg.add("Python"; version="3.9", channel="conda-forge")
```

Here is the Python version that is installed:
```
  + python                3.9.0  hffdb5ce_5_cpython  conda-forge/linux-64     Cached
```

However, I would expect it to install 3.9.13. From experimentation, this only happens when the version info is stored inside the brackets next to the package name. For example: `"python[version='3.9',channel='conda-forge']"`. 


I found that a fix for this behavior is to move the version information outside of the brackets. The example above would become `"python[channel='conda-forge']=3.9"`. Moving the version outside of the brackets results in the following python package to be installed:
```
  + python               3.9.13  h2660328_0_cpython  conda-forge/linux-64     Cached
```

You can also do this with the current `specstr` by setting the version python version to `=3.9`.

This behavior happens with every package that I have tested. For example, setting the pandas version to `1.4` installs `1.4.0` instead of the latest patch, `1.4.3`.

Edit: Nevermind, I just think that I didn't fully understand the package management format. This will break things despite the test suite working. 