### PR TITLE
rework tests to show summary (sections)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Test", "TestItemRunner"]
+test = ["Test"]

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -1,4 +1,4 @@
-@testitem "PkgSpec" begin
+@testset "PkgSpec" begin
     include("setup.jl")
     @test_throws Exception CondaPkg.PkgSpec("")
     @test_throws Exception CondaPkg.PkgSpec("foo!")
@@ -9,14 +9,14 @@
     @test spec.channel == "SOME_chaNNEL"
 end
 
-@testitem "ChannelSpec" begin
+@testset "ChannelSpec" begin
     include("setup.jl")
     @test_throws Exception CondaPkg.ChannelSpec("")
     spec = CondaPkg.ChannelSpec("  SOME_chaNNEL  ")
     @test spec.name == "SOME_chaNNEL"
 end
 
-@testitem "PipPkgSpec" begin
+@testset "PipPkgSpec" begin
     include("setup.jl")
     @test_throws Exception CondaPkg.PipPkgSpec("")
     @test_throws Exception CondaPkg.PipPkgSpec("foo!")
@@ -26,7 +26,7 @@ end
     @test spec.version == "@./SOME/Path"
 end
 
-@testitem "meta IO" begin
+@testset "meta IO" begin
     include("setup.jl")
     specs = Any[
         CondaPkg.PkgSpec("foo", version="=1.2.3", channel="bar"),
@@ -45,7 +45,7 @@ end
     end
 end
 
-@testitem "abspathurl" begin
+@testset "abspathurl" begin
     include("setup.jl")
     @test startswith(CondaPkg.abspathurl("foo"), "file://")
     @test endswith(CondaPkg.abspathurl("foo"), "/foo")

--- a/test/main.jl
+++ b/test/main.jl
@@ -1,10 +1,10 @@
-@testitem "resolve (empty)" begin
+@testset "resolve (empty)" begin
     include("setup.jl")
     @test CondaPkg.resolve() === nothing
     @test occursin("(empty)", status())
 end
 
-@testitem "Null backend" begin
+@testset "Null backend" begin
     include("setup.jl")
     if isnull
         @test CondaPkg.backend() == :Null
@@ -14,7 +14,7 @@ end
     end
 end
 
-@testitem "add/remove channel" begin
+@testset "add/remove channel" begin
     include("setup.jl")
     @test !occursin("conda-forge", status())
     CondaPkg.add_channel("conda-forge")
@@ -23,7 +23,7 @@ end
     @test !occursin("conda-forge", status())
 end
 
-@testitem "install python" begin
+@testset "install python" begin
     include("setup.jl")
     @test !occursin("python", status())
     CondaPkg.add("python", version="==3.10.2")
@@ -34,7 +34,7 @@ end
     @test occursin("python", status())
 end
 
-@testitem "install/remove python package" begin
+@testset "install/remove python package" begin
     include("setup.jl")
     CondaPkg.add("python", version="==3.10.2")
     # verify package isn't already installed
@@ -60,7 +60,7 @@ end
     end
 end
 
-@testitem "pip install/remove python package" begin
+@testset "pip install/remove python package" begin
     include("setup.jl")
     CondaPkg.add("python", version="==3.10.2")
     # verify package isn't already installed
@@ -87,7 +87,7 @@ end
 end
 
 
-@testitem "install/remove executable package" begin
+@testset "install/remove executable package" begin
     include("setup.jl")
     if !isnull
         CondaPkg.add("curl", resolve=false)
@@ -101,7 +101,7 @@ end
     end
 end
 
-@testitem "install/remove libstdcxx_ng" begin
+@testset "install/remove libstdcxx_ng" begin
     include("setup.jl")
     CondaPkg.add("libstdcxx-ng", version="<=julia", resolve=false)
     CondaPkg.resolve(force=true)
@@ -109,14 +109,14 @@ end
     CondaPkg.resolve(force=true)
 end
 
-@testitem "gc()" begin
+@testset "gc()" begin
     include("setup.jl")
     if testgc
         CondaPkg.gc()
     end
 end
 
-@testitem "validation" begin
+@testset "validation" begin
     include("setup.jl")
     @test_throws Exception CondaPkg.add("!invalid!package!")
     @test_throws Exception CondaPkg.add_pip("!invalid!package!")

--- a/test/pkgrepl.jl
+++ b/test/pkgrepl.jl
@@ -2,7 +2,7 @@
 # but calling them is the closest thing to calling
 # the Pkg REPL.
 
-@testitem "add/rm package" begin
+@testset "add/rm package" begin
     include("setup.jl")
     CondaPkg.PkgREPL.add(["  six ==1.16.0 "])
     @test occursin("six", status())
@@ -11,7 +11,7 @@
     @test !occursin("six", status())
 end
 
-@testitem "add/rm channel" begin
+@testset "add/rm channel" begin
     include("setup.jl")
     CondaPkg.PkgREPL.channel_add([" numba "])
     @test occursin("numba", status())
@@ -19,7 +19,7 @@ end
     @test !occursin("numba", status())
 end
 
-@testitem "add/rm pip package" begin
+@testset "add/rm pip package" begin
     include("setup.jl")
     CondaPkg.PkgREPL.pip_add([" six ==1.16.0 "])
     @test occursin("six", status())
@@ -28,25 +28,25 @@ end
     @test !occursin("six", status())
 end
 
-@testitem "status" begin
+@testset "status" begin
     include("setup.jl")
     # TODO: capture the output and check it equals status()
     CondaPkg.PkgREPL.status()
 end
 
-@testitem "resolve" begin
+@testset "resolve" begin
     include("setup.jl")
     CondaPkg.PkgREPL.resolve()
 end
 
-@testitem "gc" begin
+@testset "gc" begin
     include("setup.jl")
     if testgc
         CondaPkg.PkgREPL.gc()
     end
 end
 
-@testitem "run" begin
+@testset "run" begin
     include("setup.jl")
     CondaPkg.add("python", version="==3.10.2")
     # TODO: capture the output and check it contains "Python 3.10.2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
-using TestItemRunner
+using CondaPkg
+using Test
 
-@run_package_tests
+include("internals.jl")
+include("pkgrepl.jl")
+include("main.jl")


### PR DESCRIPTION
Per https://github.com/cjdoris/CondaPkg.jl/pull/53#issuecomment-1399527692.

Rework tests to use the default `Test` package instead of `TestItemRunner` (I don't see the added value of using this dependency), allowing to show the `@testset` description while running the tests, thus categorizing stdout into clear sections.

Not doing so is confusing especially when a test is failing because the failing test output is mixed with the `CondaPkg / μmamba` output from a previous non-failing test.

Example output:
```julia
[...]
Test Summary:  | Pass  Total     Time
add/rm package |    3      3  1m40.4s
    CondaPkg Found dependencies: /tmp/jl_vtam3r/CondaPkg.toml
    CondaPkg Dependencies already up to date
    CondaPkg Dependencies already up to date
Test Summary:  | Pass  Total  Time
add/rm channel |    2      2  0.7s
[...]
```