### PR TITLE
add `conda update / conda up`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## main
+* Add `update` function and REPL command.
+
 ## 0.2.16 (2023-01-23)
 * Allow `JULIA_CONDAPKG_ENV` to specify the location of a shared Conda environment.
 * The PkgREPL now supports the prefixes `@` for versions and `#` for build string.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ pkg> conda add python perl       # adds conda packages
 pkg> conda pip_add build         # adds pip packages
 pkg> conda rm perl               # removes conda packages
 pkg> conda run python --version  # runs the given command in the conda environment
+pkg> conda update                # update conda and pip installed packages
 ```
 
 For more information do `?` or `?conda` from the Pkg REPL.
@@ -98,6 +99,7 @@ binary = "no"  # or "only"
 - `resolve(; force=false)` resolves dependencies. You don't normally need to call this
   because the other API functions will automatically resolve first. Pass `force=true` if
   you change a `CondaPkg.toml` file mid-session.
+- `update()` update the conda and pip installed packages.
 - `gc()` removes unused caches to save disk space.
 
 ### Examples

--- a/src/PkgREPL.jl
+++ b/src/PkgREPL.jl
@@ -98,6 +98,27 @@ const resolve_spec = Pkg.REPLMode.CommandSpec(
     option_spec = [force_opt],
 )
 
+### update
+
+function update()
+    CondaPkg.resolve(force=true, interactive=true)
+end
+
+const update_help = Markdown.parse("""
+```
+conda update
+```
+
+Update Conda dependencies.
+""")
+
+const update_spec = Pkg.REPLMode.CommandSpec(
+    name = "update",
+    api = update,
+    help = update_help,
+    description = "update Conda dependencies",
+)
+
 ### add
 
 function add(args)
@@ -303,7 +324,7 @@ const gc_spec = Pkg.REPLMode.CommandSpec(
     description = "delete files no longer used by Conda",
 )
 
-## run
+### run
 
 function run(args)
     CondaPkg.withenv() do
@@ -334,6 +355,8 @@ const SPECS = Dict(
     "st" => status_spec,
     "status" => status_spec,
     "resolve" => resolve_spec,
+    "up" => update_spec,
+    "update" => update_spec,
     "add" => add_spec,
     "remove" => rm_spec,
     "rm" => rm_spec,

--- a/src/PkgREPL.jl
+++ b/src/PkgREPL.jl
@@ -101,7 +101,7 @@ const resolve_spec = Pkg.REPLMode.CommandSpec(
 ### update
 
 function update()
-    CondaPkg.resolve(force=true, interactive=true)
+    CondaPkg.update()
 end
 
 const update_help = Markdown.parse("""

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -547,3 +547,7 @@ function is_resolved()
     resolve(io=devnull, dry_run=true)
     STATE.resolved
 end
+
+function update()
+    resolve(force=true, interactive=true)
+end

--- a/test/main.jl
+++ b/test/main.jl
@@ -135,7 +135,13 @@ end
     end
 end
 
-@testitem "gc()" begin
+@testitem "update" begin
+    include("setup.jl")
+    CondaPkg.update()
+    @test CondaPkg.is_resolved()
+end
+
+@testitem "gc" begin
     include("setup.jl")
     testgc && CondaPkg.gc()
     @test true

--- a/test/pkgrepl.jl
+++ b/test/pkgrepl.jl
@@ -39,6 +39,11 @@ end
     CondaPkg.PkgREPL.resolve()
 end
 
+@testitem "update" begin
+    include("setup.jl")
+    CondaPkg.PkgREPL.update()
+end
+
 @testitem "gc" begin
     include("setup.jl")
     testgc && CondaPkg.PkgREPL.gc()

--- a/test/pkgrepl.jl
+++ b/test/pkgrepl.jl
@@ -37,16 +37,19 @@ end
 @testitem "resolve" begin
     include("setup.jl")
     CondaPkg.PkgREPL.resolve()
+    @test CondaPkg.is_resolved()
 end
 
 @testitem "update" begin
     include("setup.jl")
     CondaPkg.PkgREPL.update()
+    @test CondaPkg.is_resolved()
 end
 
 @testitem "gc" begin
     include("setup.jl")
     testgc && CondaPkg.PkgREPL.gc()
+    @test true
 end
 
 @testitem "run" begin


### PR DESCRIPTION
Naive implemented of `conda update` (short version `conda up`).

Fix https://github.com/cjdoris/CondaPkg.jl/issues/60.
Fix https://github.com/cjdoris/CondaPkg.jl/issues/49.

~~Should we add a `--pip` option to update pip packages and limit the update to the conda installed pkgs by default ?~~