### PR TITLE
current_pip_packages now respects the pip_backend preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Bug fixes.
+
 ## 0.2.35 (2026-05-14)
 * Stop using deprecated `[project]` in `pixi.toml`.
 * Pixi backends now support the `binary=no` and `binary=only` options for pip dependencies.

--- a/src/deps.jl
+++ b/src/deps.jl
@@ -148,8 +148,18 @@ function current_pip_packages()
     b = backend()
     if b in CONDA_BACKENDS
         pkglist = withenv() do
-            cmd = `$(which("pip")) list --format=json`
-            JSON.parse(cmd)
+            pip_backend = getpref_pip_backend()
+            if pip_backend == :pip
+                pip_cmd = which("pip")
+                pip_cmd === nothing && error("pip not installed")
+                JSON.parse(`$pip_cmd list --format=json`)
+            elseif pip_backend == :uv
+                uv_cmd = which("uv")
+                uv_cmd === nothing && error("uv not installed")
+                JSON.parse(`$uv_cmd pip list --format=json`)
+            else
+                error("not implemented")
+            end
         end
     elseif b in PIXI_BACKENDS
         cmd =


### PR DESCRIPTION
this is a bugfix because previously it only used pip, which is not always installed