### PR TITLE
do not override detached-environments pixi config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* On Pixi backends, respect the user's existing `detached-environment` config.
+
 ## 0.2.36 (2026-05-16)
 * `CondaPkg.gc()` now calls `pixi clean cache` on pixi backends (previously it did nothing).
 * Bug fixes.

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -1037,7 +1037,7 @@ function resolve(;
                 force && Base.rm(joinpath(meta_dir, "pixi.lock"), force = true)
                 # write .pixi/config.toml
                 configtomlpath = joinpath(meta_dir, ".pixi", "config.toml")
-                configtoml = Dict{String,Any}("detached-environments" => false)
+                configtoml = Dict{String,Any}()
                 configtomlstr = sprint(TOML.print, configtoml)
                 mkpath(dirname(configtomlpath))
                 write(configtomlpath, configtomlstr)


### PR DESCRIPTION
We previously set `detached-environments=false` in pixi config to ensure we know where the environment is put.

It turns out that it's not necessary - even when true and the environment is put somewhere else, a symlink is still created to it at the usual place, so everything still works fine.

Hence we now respect the user's detached-environments config.

Fixes #210.